### PR TITLE
Changes to 2020.06 crazyflie-firmware to accomodate ModQuad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,12 @@ CFLAGS += $(PROCESSOR) $(INCLUDES)
 
 
 CFLAGS += -Wall -Wmissing-braces -fno-strict-aliasing $(C_PROFILE) -std=gnu11
+
+#### ModQuad: Add -Wno-address-of-packed-member, that seems to be present in 
+####		new GCC and not accounted for in this repo
+CFLAGS += -Wno-address-of-packed-member
+
+
 # Compiler flags to generate dependency files:
 CFLAGS += -MD -MP -MF $(BIN)/dep/$(@).d -MQ $(@)
 #Permits to remove un-used functions and global variables from output file

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ModQuad
 There are small differences in this firmware to account for necessary functionalities of the [ModQuad Project](https://github.com/swarmslab/modquad-simulator).
 
+The file in src/modules/src/power_distribution_stock.c has been modified. The Makefile is set to ignore -Waddress-of-packed-member as this warning is turned into many errors. This seems to be related to GCC version and might be fixed in future releases of crazyflie-firmware. For now, the warning has only been disabled to allow for compilation.
+
 # Crazyflie Firmware  [![Build Status](https://api.travis-ci.org/bitcraze/crazyflie-firmware.svg)](https://travis-ci.org/bitcraze/crazyflie-firmware)
 
 This project contains the source code for the firmware used in the Crazyflie range of platforms, including

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ModQuad
-There are small differences in this firmware to account for necessary functionalities of the [ModQuad Project](https://github.com/swarmslab/modquad-simulator). for details.
+There are small differences in this firmware to account for necessary functionalities of the [ModQuad Project](https://github.com/swarmslab/modquad-simulator).
 
 # Crazyflie Firmware  [![Build Status](https://api.travis-ci.org/bitcraze/crazyflie-firmware.svg)](https://travis-ci.org/bitcraze/crazyflie-firmware)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ModQuad
-There are small differences in this firmware to account for necessary functionalities of the ModQuad project. See the [ModQuad Project](https://github.com/swarmslab/modquad-simulator) for details.
+There are small differences in this firmware to account for necessary functionalities of the [ModQuad Project](https://github.com/swarmslab/modquad-simulator). for details.
 
 # Crazyflie Firmware  [![Build Status](https://api.travis-ci.org/bitcraze/crazyflie-firmware.svg)](https://travis-ci.org/bitcraze/crazyflie-firmware)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ModQuad
+There are small differences in this firmware to account for necessary functionalities of the ModQuad project. See the [ModQuad Project](https://github.com/swarmslab/modquad-simulator) for details.
+
 # Crazyflie Firmware  [![Build Status](https://api.travis-ci.org/bitcraze/crazyflie-firmware.svg)](https://travis-ci.org/bitcraze/crazyflie-firmware)
 
 This project contains the source code for the firmware used in the Crazyflie range of platforms, including

--- a/src/modules/src/power_distribution_stock.c
+++ b/src/modules/src/power_distribution_stock.c
@@ -22,6 +22,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  * power_distribution_stock.c - Crazyflie stock power distribution code
+ *
+ * --------------------------------------------------------------------
+ * --------------------------------------------------------------------
+ * Changes made for ModQuad are denoted with ***...*** comment blocks
+ *
  */
 #define DEBUG_MODULE "PWR_DIST"
 
@@ -35,84 +40,132 @@
 #include "motors.h"
 #include "debug.h"
 
+/* stock */
 static bool motorSetEnable = false;
 
+/* modquad var */
+static uint16_t motor_set_timer = 0;
+
+/* more modquad vars */
+static float r1 = -1;
+static float r2 = -1;
+static float r3 = 1;
+static float r4 = 1;
+static float p1 = 1;
+static float p2 = -1;
+static float p3 = -1;
+static float p4 = 1;
+static float cz = 1;
+
+/* stock */
 static struct {
-  uint32_t m1;
-  uint32_t m2;
-  uint32_t m3;
-  uint32_t m4;
+	uint32_t m1;
+	uint32_t m2;
+	uint32_t m3;
+	uint32_t m4;
 } motorPower;
 
 static struct {
-  uint16_t m1;
-  uint16_t m2;
-  uint16_t m3;
-  uint16_t m4;
+	uint16_t m1;
+	uint16_t m2;
+	uint16_t m3;
+	uint16_t m4;
 } motorPowerSet;
 
 void powerDistributionInit(void)
 {
-  motorsInit(platformConfigGetMotorMapping());
+	motorsInit(platformConfigGetMotorMapping());
 }
 
 bool powerDistributionTest(void)
 {
-  bool pass = true;
+	bool pass = true;
 
-  pass &= motorsTest();
+	pass &= motorsTest();
 
-  return pass;
+	return pass;
 }
 
 #define limitThrust(VAL) limitUint16(VAL)
 
 void powerStop()
 {
-  motorsSetRatio(MOTOR_M1, 0);
-  motorsSetRatio(MOTOR_M2, 0);
-  motorsSetRatio(MOTOR_M3, 0);
-  motorsSetRatio(MOTOR_M4, 0);
+	motorsSetRatio(MOTOR_M1, 0);
+	motorsSetRatio(MOTOR_M2, 0);
+	motorsSetRatio(MOTOR_M3, 0);
+	motorsSetRatio(MOTOR_M4, 0);
 }
 
 void powerDistribution(const control_t *control)
 {
-  #ifdef QUAD_FORMATION_X
-    int16_t r = control->roll / 2.0f;
-    int16_t p = control->pitch / 2.0f;
-    motorPower.m1 = limitThrust(control->thrust - r + p + control->yaw);
-    motorPower.m2 = limitThrust(control->thrust - r - p - control->yaw);
-    motorPower.m3 =  limitThrust(control->thrust + r - p + control->yaw);
-    motorPower.m4 =  limitThrust(control->thrust + r + p - control->yaw);
-  #else // QUAD_FORMATION_NORMAL
-    motorPower.m1 = limitThrust(control->thrust + control->pitch +
-                               control->yaw);
-    motorPower.m2 = limitThrust(control->thrust - control->roll -
-                               control->yaw);
-    motorPower.m3 =  limitThrust(control->thrust - control->pitch +
-                               control->yaw);
-    motorPower.m4 =  limitThrust(control->thrust + control->roll -
-                               control->yaw);
-  #endif
+#ifdef QUAD_FORMATION_X
+	int16_t r = control->roll / 2.0f;
+	int16_t p = control->pitch / 2.0f;
 
-  if (motorSetEnable)
-  {
-    motorsSetRatio(MOTOR_M1, motorPowerSet.m1);
-    motorsSetRatio(MOTOR_M2, motorPowerSet.m2);
-    motorsSetRatio(MOTOR_M3, motorPowerSet.m3);
-    motorsSetRatio(MOTOR_M4, motorPowerSet.m4);
-  }
-  else
-  {
-    motorsSetRatio(MOTOR_M1, motorPower.m1);
-    motorsSetRatio(MOTOR_M2, motorPower.m2);
-    motorsSetRatio(MOTOR_M3, motorPower.m3);
-    motorsSetRatio(MOTOR_M4, motorPower.m4);
-  }
+	/*** Modified for ModQuad - M13, M14, M15, M16, respectively ***/
+	motorPower.m1 = limitThrust(control->thrust  + r1*r + p1*p + cz*control->yaw);
+	motorPower.m2 = limitThrust(control->thrust  + r2*r + p2*p - cz*control->yaw);
+	motorPower.m3 =  limitThrust(control->thrust + r3*r + p3*p + cz*control->yaw);
+	motorPower.m4 =  limitThrust(control->thrust + r4*r + p4*p - cz*control->yaw);
+	/*** End Modified for ModQuad ***/
+
+#else /* QUAD_FORMATION_NORMAL */
+	motorPower.m1 = limitThrust(control->thrust + control->pitch +
+			control->yaw);
+	motorPower.m2 = limitThrust(control->thrust - control->roll -
+			control->yaw);
+	motorPower.m3 =  limitThrust(control->thrust - control->pitch +
+			control->yaw);
+	motorPower.m4 =  limitThrust(control->thrust + control->roll -
+			control->yaw);
+#endif
+
+
+	/*** Added for ModQuad ***/
+	/* The timer is reduced on every tick */
+	if (motor_set_timer){
+		motor_set_timer--;
+	}
+	/*** End Added for ModQuad ***/
+
+	if (motorSetEnable)
+	{
+		motorsSetRatio(MOTOR_M1, motorPowerSet.m1);
+		motorsSetRatio(MOTOR_M2, motorPowerSet.m2);
+		motorsSetRatio(MOTOR_M3, motorPowerSet.m3);
+		motorsSetRatio(MOTOR_M4, motorPowerSet.m4);
+	}
+	else
+	{
+		motorsSetRatio(MOTOR_M1, motorPower.m1);
+		motorsSetRatio(MOTOR_M2, motorPower.m2);
+		motorsSetRatio(MOTOR_M3, motorPower.m3);
+		motorsSetRatio(MOTOR_M4, motorPower.m4);
+	}
 }
+
+/*** Add for ModQuad ***/
+PARAM_GROUP_START(var)
+PARAM_ADD(PARAM_FLOAT, roll1, &r1)
+PARAM_ADD(PARAM_FLOAT, roll2, &r2)
+PARAM_ADD(PARAM_FLOAT, roll3, &r3)
+PARAM_ADD(PARAM_FLOAT, roll4, &r4)
+PARAM_ADD(PARAM_FLOAT, pitch1, &p1)
+PARAM_ADD(PARAM_FLOAT, pitch2, &p2)
+PARAM_ADD(PARAM_FLOAT, pitch3, &p3)
+PARAM_ADD(PARAM_FLOAT, pitch4, &p4)
+PARAM_ADD(PARAM_FLOAT, czz, &cz)
+PARAM_GROUP_STOP(var)
+/*** End Add for ModQuad ***/
 
 PARAM_GROUP_START(motorPowerSet)
 PARAM_ADD(PARAM_UINT8, enable, &motorSetEnable)
+
+/*** Add for ModQuad ***/
+/* Enable based on timer */
+PARAM_ADD(PARAM_UINT16, motor_timer, &motor_set_timer)  
+/*** End Add for ModQuad ***/
+
 PARAM_ADD(PARAM_UINT16, m1, &motorPowerSet.m1)
 PARAM_ADD(PARAM_UINT16, m2, &motorPowerSet.m2)
 PARAM_ADD(PARAM_UINT16, m3, &motorPowerSet.m3)


### PR DESCRIPTION
Files changed:
* Makefile: disable warning for -Waddress-of-packed-member. This warning (using -Werror) causes many compilation errors and presumably do not impede runtime performance since stock firmware also has them when compiled locally. This seems to be caused by specific version of compiler being used.
* src/modules/src/power_distribution_stock.c: changes made in original [ModQuad firmware](https://github.com/dsaldana/modquad-firmware/blob/master/src/modules/src/power_distribution_stock.c) are copied into the updated crazyflie-firmware
* Using 2020.06 crazyflie-firmware as base because 2020.09 did not work when tried